### PR TITLE
Fix issue that incorrectly subscribed users in Campaign monitor

### DIFF
--- a/app/code/community/Campaignmonitor/Createsend/Model/List/Cron.php
+++ b/app/code/community/Campaignmonitor/Createsend/Model/List/Cron.php
@@ -79,7 +79,7 @@ class Campaignmonitor_Createsend_Model_List_Cron extends Campaignmonitor_Creates
 
                 if (!$mageNewsletter->isSubscribed() || $mageNewsletter->getId() === null) {
                     $mageTimestamp = null;
-                    if ($mageNewsletter->getId() !== null) {
+                    if ($mageNewsletter->getId() !== null && !empty($mageNewsletter->getChangeStatusAt())) {
                         $mageTime = Mage::getModel('core/date')->timestamp($mageNewsletter->getChangeStatusAt());
                         $mageTimestamp = date('Y-m-d H:i:s', $mageTime);
                     }
@@ -158,9 +158,12 @@ class Campaignmonitor_Createsend_Model_List_Cron extends Campaignmonitor_Creates
                 }
 
                 if ($subscriptionState !== $api::SUBSCRIBER_STATUS_ACTIVE) {
-                    // Convert to local time
-                    $mageTime = Mage::getModel('core/date')->timestamp($subscriber->getChangeStatusAt());
-                    $mageTimeStamp = date('Y-m-d H:i:s', $mageTime);
+                    $mageTimeStamp = null;
+                    if (!empty($subscriber->getChangeStatusAt())) {
+                        // Convert to local time
+                        $mageTime = Mage::getModel('core/date')->timestamp($subscriber->getChangeStatusAt());
+                        $mageTimeStamp = date('Y-m-d H:i:s', $mageTime);
+                    }
 
                     // CM in local time
                     $cmTimestamp = null;


### PR DESCRIPTION
When null is passed to the core timestamp function, it returns the
current date. If the extension is in the default "timestamp" mode, it
will compare this timestamp to the last updated timestamp in CM. By
default Magento has a null value for the change status at attribute,
which means they are interpreted as todays date, instead of no date.
This change ensures we pass through an actual null time when no changed
status at date is available in Magento.